### PR TITLE
Improve QR Code scanning

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -425,15 +425,7 @@ parentViewController:(UIViewController*)parentViewController
 
     [output setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
     output.metadataObjectTypes = @[
-        AVMetadataObjectTypeUPCECode,
-        AVMetadataObjectTypeCode39Code,
-        AVMetadataObjectTypeEAN13Code,
-        AVMetadataObjectTypeEAN8Code,
-        AVMetadataObjectTypeCode93Code,
-        AVMetadataObjectTypeCode128Code,
-        AVMetadataObjectTypeQRCode,
-        AVMetadataObjectTypeITF14Code,
-        AVMetadataObjectTypeDataMatrixCode
+        AVMetadataObjectTypeQRCode
     ];
 
     if (![captureSession canSetSessionPreset:AVCaptureSessionPresetMedium]) {

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -399,8 +399,8 @@ parentViewController:(UIViewController*)parentViewController
     AVCaptureDeviceInput* input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
     if (!input) return @"unable to obtain video capture device input";
 
-    captureSession.sessionPreset = AVCaptureSessionPresetMedium;
-    
+    captureSession.sessionPreset = AVCaptureSessionPresetHigh;
+
     if ([captureSession canAddInput:input]) {
         [captureSession addInput:input];
     }
@@ -428,8 +428,8 @@ parentViewController:(UIViewController*)parentViewController
         AVMetadataObjectTypeQRCode
     ];
 
-    if (![captureSession canSetSessionPreset:AVCaptureSessionPresetMedium]) {
-        return @"unable to preset medium quality video capture";
+    if (![captureSession canSetSessionPreset:AVCaptureSessionPresetHigh]) {
+        return @"unable to preset high quality video capture";
     }
   
     // setup capture preview layer


### PR DESCRIPTION
Limit number symbologies the scanner needs to detect. This should help with detection speed. Apple recommends opting into only the symbologies needed in this [WWDC talk](https://developer.apple.com/videos/play/wwdc2013/610/).

Increase capture quality for small codes. Also an Apple recommendation from this [TechNote](https://developer.apple.com/library/ios/technotes/tn2325/_index.html#//apple_ref/doc/uid/DTS40013824-CH1-HOW_CAN_I_IMPROVE_SCANNING_RESULTS_ON_VERY_SMALL_OR_VERY_DENSE_CODES_).

One more option to try is to set the zoom factor so that there are fewer total pixel for the scanner to process. However, this does reduce the field of view and may make it harder for kids to get the badge in place. 

@benchun – **OR** we could go for the front camera? Kids are good at selfies these days, right?
